### PR TITLE
Hinweis in README zu picins installation

### DIFF
--- a/README
+++ b/README
@@ -6,7 +6,11 @@ erforderlich, wie sie jeder typischen Linux Distribution beiliegt.
 
 Zusätzlich wird das Paket `picins` (http://tug.ctan.org/pkg/picins) benötigt.
 Mit MiKTeX sollte es automatisch installiert werden, unter TeXlive muss es aus
-lizenztechnischen Gründen manuell nachinstalliert werden.
+lizenztechnischen Gründen manuell nachinstalliert werden. Dies kann am
+einfachsten folgendermassen getan werden:
+
+    $ cd skript
+    $ wget http://mirror.unl.edu/ctan/macros/latex209/contrib/picins/picins.sty
 
 Sofern alle Abhängigkeiten erfüllt sind, kann das Skript folgendermassen
 gebaut werden:


### PR DESCRIPTION
Es reicht, wenn man `picins.sty` in den `skript` Ordner kopiert.

Man könnte das File auch direkt ins Repository committen. MikTeX liefert es ja beispielsweise mit. Der eine Autor ist verstorben, der andere Autor konnte nicht kontaktiert werden. http://www.tug.org/pipermail/tex-live/2007-December/015186.html Allerdings ist das Package trotzdem nicht unter einer freien Lizenz.
