### PR TITLE
bugfix regulaer.tex

### DIFF
--- a/skript/regulaer.tex
+++ b/skript/regulaer.tex
@@ -1366,8 +1366,8 @@ Zustand $q_2$ hinzugef"ugt werden muss.
 			&*+\txt{}\ar[ul]
 }
 \]
-In diesem Automaten sind die Zust"ande $q_{001}$ und $q_{101}$ nicht
-mehr unerreichbar, man kann sie weglassen.
+In diesem Automaten sind die Zust"ande $q_{001}$ und $q_{011}$ nicht
+mehr erreichbar, man kann sie weglassen.
 \[
 \entrymodifiers={++[o][F]}
 \xymatrix{


### PR DESCRIPTION
Anhand des nachfolgenden Bildes ist es der Zustand q001 und q011 welcher nicht mehr erreichbar ist und darum weggelassen werden kann. So zumindest nach meinem Verständnis.
Nicht mehr unereichbar würde zudem bedeuten dass der Zustand nun wieder erreichbar ist, was aber nicht der Fall ist, und daher hat sich nach meinem Verständnis ein Fehler eingeschlichen. 
