### PR TITLE
Fixing typos for akzeptiert.

### DIFF
--- a/skript/regulaer.tex
+++ b/skript/regulaer.tex
@@ -1730,8 +1730,8 @@ verwenden, einen Automaten zu bauen, der $L_1\cup L_2$
 akzeptiert.
 Der kartesische Produktautomat simuliert ja sozusagen
 beide Teilautomaten in den beiden Komponenten der Zustände.
-Aktzeptabel ist ein Wort $w$, wenn es von $A_1$
-oder von $A_2$ akzueptiert ist, oder wenn der Produktautomat
+Akzeptabel ist ein Wort $w$, wenn es von $A_1$
+oder von $A_2$ akzeptiert ist, oder wenn der Produktautomat
 sich am Ende des Wortes in einem Zustand befindet, der ein
 Akzeptierzustand von $A_1$ ist oder von $A_2$.
 Verwendet
@@ -1996,7 +1996,7 @@ $\varepsilon$-Übergang von einem Akzeptierzustand zum Startzustand
 nicht hinzugefügt werden.
 Um das leere Wort muss daher ein zusätzlicher Zustand hinzugefügt werden.
 Und für die Wiederholung darf kann man diesen neuen Zustand ebenfalls
-verwenden, indem man von den Aktzeptierzuständen von $A$ zu diesem
+verwenden, indem man von den Akzeptierzuständen von $A$ zu diesem
 neuen Zustand zurückkehrt.
 So erhält man den Automaten
 \begin{center}


### PR DESCRIPTION
Fixed typos where the words "Akzeptabel" and "akzeptiert" were spelled wrong.