### PR TITLE
Regex-Beispiel um Programmiersprache C# erweitert

### DIFF
--- a/code/regex/csharp/Program.cs
+++ b/code/regex/csharp/Program.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace csharp
+{
+    public static class Program
+    {
+	    private const int N = 29;
+
+	    public static void Main(string[] args)
+        {
+	        if (args.Length != 1 || !bool.TryParse(args[0], out var useCompiled))
+	        {
+		        Console.WriteLine("Verwendung: dotnet run [false|true]");
+		        return;
+	        }
+	        
+	        Console.WriteLine(useCompiled ? "Match mit 'Compiled' flag:" : "Match ohne Optionen:");
+	        
+	        var regexOptions = useCompiled ? RegexOptions.Compiled : RegexOptions.None;
+	        var	s1 = string.Empty;
+	        var	s2 = string.Empty;
+	        // baue einen Präfix-String fuer die "schöne" Einrückung
+	        // der Resultate
+	        var prefix = string.Empty;
+	        for (var i = 0; i < N; i++) {
+		        prefix += " ";
+	        }
+
+	        // führe den Test durch fuer Stringlängen von 1 bis N
+	        for (var i = 1; i <= N; i++) {
+		        // Stringkomponenten verlaengern
+		        s1 += "a";
+		        s2 += "a?";
+		        var	r = s2 + s1;
+		        Console.Write(prefix.Substring(i));
+		        Console.Write(s1);
+		        Console.Write(Regex.IsMatch(s1, r, regexOptions) ? " matches " : " doesn't match ");
+		        Console.WriteLine(r);
+	        }
+        }
+    }
+}

--- a/code/regex/csharp/csharp.csproj
+++ b/code/regex/csharp/csharp.csproj
@@ -1,0 +1,6 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
Nach der heutigen Vorlesung musste ich natürlich verifizieren, dass die Regex-Engine von C# besser sein muss, als jene in Java. Zu meinem Schrecken musste ich nach Testen jedoch feststellen, dass dies nicht der Fall ist.
Auch C# leidet wohl unter "Feature-itis" 😨 - immerhin [verspricht .NET 5 besserung](https://github.com/dotnet/runtime/issues/23683).

Vorbedingung:
- Lokal Installiertes [.NET Core SDK](https://dotnet.microsoft.com/download)

Verwendung:
- `dotnet run true` - Mit Option 'Compiled', etwa vier mal schneller, aber immer noch langsam
- `dotnet run false` - Ohne Optionen, fast so langsam wie Python