### PR TITLE
Binärdarstellung verwendet nur Binärzeichen

### DIFF
--- a/aufgaben/6/60000030.tex
+++ b/aufgaben/6/60000030.tex
@@ -20,7 +20,7 @@ in allen Fällen korrekt arbeitet?
 
 \begin{loesung}
 \begin{teilaufgaben}
-\item Sei $\Sigma=\{\texttt{9},\texttt{1}\}$. Die Sprache
+\item Sei $\Sigma=\{\texttt{0},\texttt{1}\}$. Die Sprache
 \[
 L=\left\{w\in\Sigma^*\,\left|
 \begin{minipage}{4truein}


### PR DESCRIPTION
Nach meinem aktuellen Wissensstand sind die Binärzeichen `0` und `1` normalerweise verwendet, nicht aus `9` und `1`