### PR TITLE
Add time to go sample regex performance testing

### DIFF
--- a/code/regex/go/regex.go
+++ b/code/regex/go/regex.go
@@ -1,6 +1,7 @@
 package main
 
 import "fmt"
+import "time"
 import "regexp"
 
 func main() {
@@ -12,13 +13,15 @@ func main() {
     r2 += "a"
     regex := r1 + r2
     r, err := regexp.Compile(regex)
+    start := time.Now()
 
     if err != nil {
       fmt.Println(err)
     }
 
     if r.MatchString(r2) {
-      fmt.Println(r2 + " matches " + regex)
+      duration := time.Since(start)
+      fmt.Println(r2 + " matches " + regex + " ", duration)
     }
 	}
 }


### PR DESCRIPTION
Zeigt zwar 0s an, aber so weiss man sicher, dass das eigentliche Regex Parsen nur 0s geht. Denn wenn man das erste mal go run regex.go aufruft, geht es etwas länger, da zuerst noch compiliert werden muss. So könnte man fälschlicherweise meinen, dass einen NEA, statt DEA im Einsatz ist. 