### PR TITLE
Update .NET version for improved Regex performance

### DIFF
--- a/code/regex/csharp/csharp.csproj
+++ b/code/regex/csharp/csharp.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
.NET hat in Version 5 einige Verbesserungen in ihrer Regex Engine eingebaut, die die Performance massiv verbessern. Details dazu sind [hier](https://devblogs.microsoft.com/dotnet/regex-performance-improvements-in-net-5/) & [hier](https://devblogs.microsoft.com/dotnet/performance-improvements-in-net-5/#regular-expressions) zu finden.

Dies sind die Resultate von `time` vorher:
```
real    0m57.760s
user    0m58.071s
sys     0m0.223s
```

Und mit .NET 6:
```
real    0m2.636s
user    0m1.696s
sys     0m0.113s
```