### PR TITLE
Add emacs-lisp-regex-tester as string and buffer

### DIFF
--- a/code/regex/emacs-lisp/regex-buffer.el
+++ b/code/regex/emacs-lisp/regex-buffer.el
@@ -1,0 +1,13 @@
+;; emacs -Q --script regex-buffer.el
+(with-temp-buffer
+  (let* ((s1 "a")
+         (s2 "a?")
+         (regex (concat s1 s2)))
+    (dotimes (_ 29)
+      (insert "a")
+      (goto-char (point-min))
+      (when (re-search-forward regex (point-max) nil 1) (message "%s matches %s" (buffer-string) regex))
+      (setq
+       s1 (concat s1 "a")
+       s2 (concat s2 "a?")
+       regex (concat s1 s2)))))

--- a/code/regex/emacs-lisp/regex-string.el
+++ b/code/regex/emacs-lisp/regex-string.el
@@ -1,0 +1,9 @@
+;; emacs -Q --script regex-string.el
+(let* ((s1 "a")
+       (s2 "a?")
+       (regex (concat s1 s2)))
+  (dotimes (_ 29)
+    (when (string-match-p regex s1) (message "%s matches %s" s1 regex))
+    (setq s1 (concat s1 "a")
+          s2 (concat s2 "a?")
+          regex (concat s1 s2))))


### PR DESCRIPTION
Emacs-lisp uses following C-Code:
https://github.com/emacs-mirror/emacs/blob/320e33a85f518578d00456a7a157927ca13448d6/src/search.c#L1160
which uses following method of the regex-c-library (regexec):
[re_search_2](https://github.com/emacs-mirror/emacs/blob/master/lib/regexec.c#L304)

That's probably ending up to be nearly same results as C example.

Please just close if that's not worth adding.