### PR TITLE
Update 40000004.tex

### DIFF
--- a/aufgaben/4/40000004.tex
+++ b/aufgaben/4/40000004.tex
@@ -48,7 +48,7 @@ ist
 \begin{align*}
 S&\rightarrow NW
 \\
-N&\rightarrow N{\tt 0}\mid  \varepsilon
+N&\rightarrow N{\tt 0}\mid  0
 \\
 W&\rightarrow {\tt 0}W{\tt 1}\mid \varepsilon
 \end{align*}


### PR DESCRIPTION
Die Regel N -> epsilon erlaubt das Generieren des Wortes 01, welches  nicht in der Sprache L = {0^n 1^m | n > m} ist.

Meine Grammatik erlaubt das so nicht:
S -> N W
N -> N 0 | 0
W -> 0 W 1 | EPSILON

S -> N W -> 0 W -> 0 0 W 1 -> 0 0 1
S -> N W -> 0 W -> 0 0 W 1 -> 0 0 0 W 1 1 -> 0 0 0 1 1

mit https://flaci.com/kfgedit geprüft.